### PR TITLE
libpasswdqc.3: provide a top-level definition of passwdqc_params_t

### DIFF
--- a/libpasswdqc.3
+++ b/libpasswdqc.3
@@ -32,6 +32,12 @@ Password strength checking library
 .Pq libpasswdqc, -lpasswdqc
 .Sh SYNOPSIS
 .In passwdqc.h
+.Bd -literal
+typedef struct {
+	passwdqc_params_qc_t qc;
+	passwdqc_params_pam_t pam;
+} passwdqc_params_t;
+.Ed
 .Ft void
 .Fn passwdqc_params_reset "passwdqc_params_t *params"
 .Ft int


### PR DESCRIPTION
This description should make clear the relationship between
passwdqc_params_t and passwdqc_params_qc_t types.