### PR TITLE
github: switch from actions/checkout@v2 to actions/checkout@v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
   whitespace-errors:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: check
       run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 
@@ -16,7 +16,7 @@ jobs:
       CC: gcc-12
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -30,7 +30,7 @@ jobs:
       CC: gcc-11
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -44,7 +44,7 @@ jobs:
       CC: gcc-10
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -58,7 +58,7 @@ jobs:
       CC: gcc
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -72,7 +72,7 @@ jobs:
       CC: gcc-8
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -86,7 +86,7 @@ jobs:
       CC: clang-14
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -100,7 +100,7 @@ jobs:
       CC: clang-13
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -114,7 +114,7 @@ jobs:
       CC: clang-12
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -128,7 +128,7 @@ jobs:
       CC: clang-11
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -142,7 +142,7 @@ jobs:
       CC: clang
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -156,7 +156,7 @@ jobs:
       CC: clang-9
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies
@@ -170,7 +170,7 @@ jobs:
       CC: clang-8
       TARGET: x86_64
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
     - name: install dependencies


### PR DESCRIPTION
This fixes the following diagnostic warning:

  Node.js 12 actions are deprecated. For more information see:
  https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.