### PR TITLE
passwdqc 2.0.3

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,4 +1,4 @@
-	Significant changes since 2.0.2.
+	Significant changes between 2.0.2 and 2.0.3.
 
 Added pkg-config file.
 

--- a/INSTALL
+++ b/INSTALL
@@ -35,8 +35,8 @@ ldconfig(8) program to update the dynamic linker cache.
 Alternatively, on a Red Hat'ish Linux system and under an account
 configured to build RPM packages (perhaps with ~/.rpmmacros specifying
 the proper pathnames for %_topdir, %_tmppath, and %buildroot), you may
-build RPM packages by running "rpmbuild -tb passwdqc-2.0.2.tar.gz", then
-install the two binary subpackages with "rpm -Uvh passwdqc*-2.0.2*.rpm".
+build RPM packages by running "rpmbuild -tb passwdqc-2.0.3.tar.gz", then
+install the two binary subpackages with "rpm -Uvh passwdqc*-2.0.3*.rpm".
 This works due to the RPM spec file included in the tarball.
 
 Please refer to README and PLATFORMS for information on configuring your

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 #
 
 PACKAGE = passwdqc
-VERSION = 2.0.2
+VERSION = 2.0.3
 TITLE = pam_passwdqc
 SHARED_LIB = libpasswdqc.so.1
 DEVEL_LIB = libpasswdqc.so

--- a/passwdqc.h
+++ b/passwdqc.h
@@ -71,7 +71,7 @@ extern void passwdqc_params_free(passwdqc_params_t *params);
 #define F_USE_AUTHTOK			0x00000200
 #define F_NO_AUDIT			0x00000400
 
-#define PASSWDQC_VERSION		"2.0.2"
+#define PASSWDQC_VERSION		"2.0.3"
 
 extern void (*_passwdqc_memzero)(void *, size_t);
 

--- a/passwdqc.spec
+++ b/passwdqc.spec
@@ -1,6 +1,6 @@
 Summary: A password/passphrase strength checking and policy enforcement toolset.
 Name: passwdqc
-Version: 2.0.2
+Version: 2.0.3
 Release: owl1
 License: BSD-compatible
 Group: System Environment/Base
@@ -77,6 +77,17 @@ rm -rf %buildroot
 %_mandir/man3/*
 
 %changelog
+* Fri Jun 23 2023 Dmitry V. Levin <ldv-at-owl.openwall.com> 2.0.3-owl1
+- wordset_4k: Move "enroll" to the multiple spellings list (by Solar Designer)
+- Don't #include <endian.h> on macOS (by Solar Designer)
+- pwqfilter: Allow --pre-hashed after --hash* (by Solar Designer)
+- Add pkg-config file (by Egor Ignatov)
+- Makefile: add Cygwin support (by Chad Dougherty)
+- Remove non-existent symbols from the linker version script
+to fix -Wl,--no-undefined-version (by Fangrui Song)
+- pam_passwdqc: extend enforce=users to support chpasswd PAM service
+in addition to traditionally supported passwd
+
 * Sun Apr 04 2021 Solar Designer <solar-at-owl.openwall.com> 2.0.2-owl1
 - Changes by Dmitry V. Levin:
   - pam_passwdqc: enhance formatting of auto-generated policy descriptions

--- a/po/ru.po
+++ b/po/ru.po
@@ -8,7 +8,7 @@
 # Dmitry V. Levin <ldv@altlinux.org>, 2021.
 msgid ""
 msgstr ""
-"Project-Id-Version: passwdqc 2.0.2\n"
+"Project-Id-Version: passwdqc 2.0.3\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2021-03-11 20:00+0000\n"
 "PO-Revision-Date: 2021-03-11 20:00+0000\n"


### PR DESCRIPTION
- wordset_4k: Move "enroll" to the multiple spellings list (by Solar Designer)
- Don't #include <endian.h> on macOS (by Solar Designer)
- pwqfilter: Allow --pre-hashed after --hash* (by Solar Designer)
- Add pkg-config file (by Egor Ignatov)
- Makefile: add Cygwin support (by Chad Dougherty)
- Remove non-existent symbols from the linker version script to fix -Wl,--no-undefined-version (by Fangrui Song)
- pam_passwdqc: extend enforce=users to support chpasswd PAM service in addition to traditionally supported passwd