### PR TITLE
github: add gcc-14 and clang-18/clang-17/clang-16 jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   gcc11-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc-11
       TARGET: x86_64
@@ -53,7 +53,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   gcc10-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc-10
       TARGET: x86_64
@@ -67,7 +67,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   gcc9-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: gcc
       TARGET: x86_64
@@ -137,7 +137,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   clang12-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: clang-12
       TARGET: x86_64
@@ -151,7 +151,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   clang11-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: clang-11
       TARGET: x86_64
@@ -165,7 +165,7 @@ jobs:
       run: ci/run-build-and-tests.sh
 
   clang10-x86_64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     env:
       CC: clang
       TARGET: x86_64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,20 @@ jobs:
     - name: check
       run: git diff-index --check --cached 4b825dc642cb6eb9a060e54bf8d69288fbee4904
 
+  gcc14-x86_64:
+    runs-on: ubuntu-24.04
+    env:
+      CC: gcc-14
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
   gcc13-x86_64:
     runs-on: ubuntu-latest
     env:
@@ -84,6 +98,48 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       CC: gcc-8
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang18-x86_64:
+    runs-on: ubuntu-24.04
+    env:
+      CC: clang-18
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang17-x86_64:
+    runs-on: ubuntu-24.04
+    env:
+      CC: clang-17
+      TARGET: x86_64
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - name: install dependencies
+      run: ci/install-dependencies.sh
+    - name: build check
+      run: ci/run-build-and-tests.sh
+
+  clang16-x86_64:
+    runs-on: ubuntu-24.04
+    env:
+      CC: clang-16
       TARGET: x86_64
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
These two commits are verbatim copies of the corresponding https://github.com/openwall/tcb commits:
[github: switch most of ubuntu-20.04 jobs to ubuntu-latest](https://github.com/openwall/tcb/commit/52edebb2047dc967642f64ca7010394de30739eb),
[github: add gcc-14 and clang-18/clang-17/clang-16 jobs](https://github.com/openwall/tcb/commit/db2b9344c3db045175132ef804a3a39fd3616203).

Unlike tcb, this update doesn't require any changes to the code.