### PR TITLE
CI: rewrite matrix strategy using "include:" syntax instead of "exclude:"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,44 +24,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [ubuntu-latest, ubuntu-22.04]
-        cc: [gcc-14, gcc-13, gcc-12, gcc-11, gcc-10, gcc-9, clang-19, clang-18, clang-17, clang-16, clang-15, clang-14, clang-13, clang-12, clang-11]
-        target: [x86_64]
-        exclude:
-          - cc: gcc-14
-            runs-on: ubuntu-22.04
-          - cc: gcc-13
-            runs-on: ubuntu-22.04
-          - cc: gcc-12
-            runs-on: ubuntu-22.04
-          - cc: gcc-11
-            runs-on: ubuntu-22.04
-          - cc: gcc-10
-            runs-on: ubuntu-22.04
-          - cc: gcc-9
-            runs-on: ubuntu-22.04
-          - cc: clang-19
-            runs-on: ubuntu-22.04
-          - cc: clang-18
-            runs-on: ubuntu-22.04
-          - cc: clang-17
-            runs-on: ubuntu-22.04
-          - cc: clang-16
-            runs-on: ubuntu-22.04
-          - cc: clang-15
-            runs-on: ubuntu-22.04
-          - cc: clang-14
-            runs-on: ubuntu-22.04
-          - cc: clang-13
-            runs-on: ubuntu-latest
-          - cc: clang-12
-            runs-on: ubuntu-latest
-          - cc: clang-11
-            runs-on: ubuntu-latest
-    name: Build ${{ matrix.cc }}-${{ matrix.target }}
+        include:
+          - { cc: gcc-14, runs-on: ubuntu-latest }
+          - { cc: gcc-13, runs-on: ubuntu-latest }
+          - { cc: gcc-12, runs-on: ubuntu-latest }
+          - { cc: gcc-11, runs-on: ubuntu-latest }
+          - { cc: gcc-10, runs-on: ubuntu-latest }
+          - { cc: gcc-9, runs-on: ubuntu-latest }
+          - { cc: clang-19, runs-on: ubuntu-latest }
+          - { cc: clang-18, runs-on: ubuntu-latest }
+          - { cc: clang-17, runs-on: ubuntu-latest }
+          - { cc: clang-16, runs-on: ubuntu-latest }
+          - { cc: clang-15, runs-on: ubuntu-latest }
+          - { cc: clang-14, runs-on: ubuntu-latest }
+          - { cc: clang-13, runs-on: ubuntu-22.04 }
+          - { cc: clang-12, runs-on: ubuntu-22.04 }
+          - { cc: clang-11, runs-on: ubuntu-22.04 }
+    name: Build ${{ matrix.cc }}-${{ matrix.runs-on }}
     env:
       CC: ${{ matrix.cc }}
-      TARGET: ${{ matrix.target }}
+      TARGET: x86_64
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:


### PR DESCRIPTION
The "include:" syntax produces an explicit and more readable list of jobs.